### PR TITLE
Updated guzzlehttp/guzzle to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "psr-4": {"VaultTransports\\": "src/"}
     },
     "require": {
-        "guzzlehttp/guzzle": "~6.2",
+        "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^1.4",
         "guzzlehttp/promises": "^1.3"
     }


### PR DESCRIPTION
Updated guzzlehttp/guzzle to ^7.3 to allow upgrades of guzzlehttp/guzzle in other projects. 

@CSharpRU, thanks for the library! I'm curious how I can test this package update.